### PR TITLE
Update favicon and asset paths in app.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -54,26 +54,22 @@
     <meta name="robots" content="index, follow" />
 
     <!-- Favicons and app icons -->
-    <link
-      rel="icon"
-      href="%sveltekit.assets%/favicon.svg"
-      type="image/svg+xml"
-    />
-    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" sizes="32x32" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="%sveltekit.assets%/apple-touch-icon.png"
+      href="/apple-touch-icon.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="96x96"
-      href="%sveltekit.assets%/favicon-96x96.png"
+      href="/favicon-96x96.png"
     />
     <link
       rel="mask-icon"
-      href="%sveltekit.assets%/safari-pinned-tab.svg"
+      href="/safari-pinned-tab.svg"
       color="#0d9488"
     />
 
@@ -88,10 +84,10 @@
     <meta name="msapplication-TileColor" content="#0d9488" />
     <meta
       name="msapplication-config"
-      content="%sveltekit.assets%/browserconfig.xml"
+      content="/browserconfig.xml"
     />
     <meta name="theme-color" content="#0d9488" />
-    <link rel="manifest" href="%sveltekit.assets%/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" />
 
     <!-- External scripts -->
     <script


### PR DESCRIPTION
Replaced %sveltekit.assets% paths with direct root-relative paths for favicons, icons, manifest, and related assets in src/app.html. This simplifies asset references and may improve compatibility with static hosting setups.